### PR TITLE
ci: add semantic release automation with conventional commits

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,70 @@
+name: Semantic Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[release]')
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for existing tags and initialize if needed
+        run: |
+          # Check if any tags exist
+          if ! git describe --tags --abbrev=0 2>/dev/null; then
+            echo "No tags found in repository"
+
+            # Read current version from docker_version.txt
+            CURRENT_VERSION=$(cat docker_version.txt | tr -d '\n\r' | xargs)
+            # Remove any non-semver suffix
+            SEMVER_VERSION=$(echo "$CURRENT_VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+
+            echo "Creating initial tag v${SEMVER_VERSION} from docker_version.txt"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git tag -a "v${SEMVER_VERSION}" -m "Initial release v${SEMVER_VERSION}"
+            git push origin "v${SEMVER_VERSION}"
+
+            echo "Initial tag created successfully"
+          else
+            echo "Tags already exist, semantic-release will handle versioning"
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install semantic-release
+        run: |
+          npm install -g semantic-release
+          npm install -g @semantic-release/git
+          npm install -g @semantic-release/changelog
+          npm install -g @semantic-release/exec
+          npm install -g conventional-changelog-conventionalcommits
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release
+
+      - name: Summary
+        run: |
+          LATEST_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          echo "Release workflow completed"
+          echo "Latest version: $LATEST_VERSION"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,45 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "docs", "release": false },
+          { "type": "style", "release": false },
+          { "type": "refactor", "release": "patch" },
+          { "type": "test", "release": false },
+          { "type": "build", "release": "patch" },
+          { "type": "ci", "release": false },
+          { "type": "chore", "release": false }
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "echo ${nextRelease.version} > docker_version.txt"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["docker_version.txt", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains the DOWNLOAD service for OpenCitations.
 
+## Contributing
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/) for versioning and automated releases. Commit messages must follow the semantic commit format.
+
 ### Environment Variables
 
 The service requires the following environment variables. These values take precedence over the ones defined in `conf.json`:


### PR DESCRIPTION
Add automated release workflow using semantic-release to manage versioning based on conventional commit messages. The workflow:
- Analyzes commit messages to determine version bumps
- Updates docker_version.txt automatically
- Creates Git tags and GitHub releases
- Generates CHANGELOG.md

Releases are triggered by including [release] in commit messages.