### PR TITLE
feat: update OpenCitations Meta to January 2026 dump

### DIFF
--- a/html-template/download.html
+++ b/html-template/download.html
@@ -57,12 +57,12 @@ $def with (active, sp_title, current_subdomain, render)
                             <span class="display-6 oc-purple">Meta</span>
                         </div>
                         <p class="card-text">Bibliographic metadata for all publications in the OpenCitations Index</p>
-                        <p><strong>Latest: June 2025 dump</strong></p>
-                        <p>Includes data on 124M+ bibliographic entities, 376M+ authors, and 698K+ publication venues</p>
+                        <p><strong>Latest: January 2026 dump</strong></p>
+                        <p>Includes data on 129M+ bibliographic entities, 389M+ authors, and 1.3M+ publication venues</p>
                         <a href="#meta" class="btn btn-primary mt-3"><i class="fa fa-download me-2"></i>View Meta downloads</a>
                     </div>
                     <div class="card-footer text-center">
-                        <small class="text-muted">Updated on 2025-06-06</small>
+                        <small class="text-muted">Updated on 2026-01-20</small>
                     </div>
                 </div>
             </div>
@@ -99,8 +99,8 @@ $def with (active, sp_title, current_subdomain, render)
                         <div class="card-body">
                             <p>The <span class="oc-purple">Open</span><span class="oc-blue">Citations</span> Meta database stores and delivers bibliographic metadata for all publications involved in the <span class="oc-purple">Open</span><span class="oc-blue">Citations</span> Index.</p>
 
-                            <h4 class="mt-4">Most recent OpenCitations Meta data dump - June 2025</h4>
-                            <p>Released on 2025-06-06, compared to the previous version, includes metadata related to citing and cited bibliographic resources added in the <a href="https://api.crossref.org/snapshots/monthly/2025/04" target="_blank" rel="noopener noreferrer" title="Crossref dump dated April 2025">April 2025 version of Crossref</a>, as well as the <a href="https://japanlinkcenter.org/" target="_blank" rel="noopener noreferrer" title="JaLC website">December 2024 dump of JaLC (Japan Link Center)</a>.</p>
+                            <h4 class="mt-4">Most recent OpenCitations Meta data dump - January 2026</h4>
+                            <p>Released on 2026-01-20, compared to the previous version, includes metadata related to citing and cited bibliographic resources added in the <a href="https://api.crossref.org/snapshots/monthly/2025/09/all.json.tar.gz" target="_blank" rel="noopener noreferrer" title="Crossref dump dated September 2025">September 2025 version of Crossref</a>, as well as the <a href="https://datafiles.datacite.org/datafiles/public-2025" target="_blank" rel="noopener noreferrer" title="DataCite Public Data File 2025">DataCite Public Data File 2025</a>.</p>
 
                             <div class="card mb-4 bg-light">
                                 <div class="card-body">
@@ -108,25 +108,25 @@ $def with (active, sp_title, current_subdomain, render)
                                     <div class="row">
                                         <div class="col-md-4 col-sm-6 mb-3">
                                             <div class="text-center p-3">
-                                                <h3 class="oc-purple">124M+</h3>
+                                                <h3 class="oc-purple">129M+</h3>
                                                 <p class="mb-0">Bibliographic entities</p>
                                             </div>
                                         </div>
                                         <div class="col-md-4 col-sm-6 mb-3">
                                             <div class="text-center p-3">
-                                                <h3 class="oc-purple">376M+</h3>
+                                                <h3 class="oc-purple">389M+</h3>
                                                 <p class="mb-0">Authors</p>
                                             </div>
                                         </div>
                                         <div class="col-md-4 col-sm-6 mb-3">
                                             <div class="text-center p-3">
-                                                <h3 class="oc-purple">1M+</h3>
+                                                <h3 class="oc-purple">1.3M+</h3>
                                                 <p class="mb-0">Publication venues</p>
                                             </div>
                                         </div>
                                     </div>
                                     <div class="text-center">
-                                        <small class="text-muted">2,765,927 editors and 103,928,927 publishers (counted by roles, without disambiguating individuals)</small>
+                                        <small class="text-muted">2,862,406 editors and 106,791,171 publishers (counted by roles, without disambiguating individuals)</small>
                                     </div>
                                 </div>
                             </div>
@@ -144,23 +144,23 @@ $def with (active, sp_title, current_subdomain, render)
                                     <tbody>
                                         <tr>
                                             <td>Metadata (CSV)</td>
-                                            <td><a href="https://doi.org/10.5281/zenodo.15625651" title="Metadata dump dated June 2025" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download tar.gz</a></td>
-                                            <td>12G (49G uncompressed)</td>
+                                            <td><a href="https://doi.org/10.5281/zenodo.18324537" title="Metadata dump dated January 2026" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download tar.gz</a></td>
+                                            <td>13G (51G uncompressed)</td>
                                         </tr>
                                         <tr>
-                                            <td>Metadata database (Kubernetes ready)</td>
-                                            <td><a href="https://doi.org/10.5281/zenodo.15855111" title="Metadata dump dated June 2025" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
-                                            <td>39G (187G uncompressed)</td>
+                                            <td>Metadata database (OpenLink Virtuoso)</td>
+                                            <td><a href="https://doi.org/10.5281/zenodo.18330418" title="Metadata dump dated January 2026" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
+                                            <td>42G (190G uncompressed)</td>
                                         </tr>
                                         <tr>
                                             <td>Metadata and provenance (RDF)</td>
-                                            <td><a href="https://doi.org/10.5281/zenodo.17483301" title="Metadata RDF dump dated June 2025" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
-                                            <td>46.5G (66G uncompressed)</td>
+                                            <td><a href="https://doi.org/10.5281/zenodo.18352502" title="Metadata RDF dump dated January 2026" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
+                                            <td>48G (69G uncompressed)</td>
                                         </tr>
                                         <tr>
-                                            <td>Provenance database (RDF)</td>
-                                            <td><a href="https://doi.org/10.6084/m9.figshare.29543783.v1" title="Provenance dump dated June 2025" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
-                                            <td>154G (1TB uncompressed)</td>
+                                            <td>Provenance database (OpenLink Virtuoso)</td>
+                                            <td><a href="https://doi.org/10.6084/m9.figshare.29543783.v3" title="Provenance dump dated January 2026" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-primary">Download 7z</a></td>
+                                            <td>144G (1TB uncompressed)</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -169,6 +169,19 @@ $def with (active, sp_title, current_subdomain, render)
 
                             <h5 class="mt-4">Previous dumps</h5>
                             <div class="accordion" id="meta-previous-dumps">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#meta-dump0">
+                                            Dump created on 2025-06-06
+                                        </button>
+                                    </h2>
+                                    <div id="meta-dump0" class="accordion-collapse collapse" data-bs-parent="#meta-previous-dumps">
+                                        <div class="accordion-body">
+                                            <p>Compared to the previous version, includes metadata from the <a href="https://api.crossref.org/snapshots/monthly/2025/04">April 2025 version of Crossref</a> and the <a href="https://japanlinkcenter.org/">December 2024 dump of JaLC</a>.</p>
+                                            <p>Available in <a href="https://doi.org/10.5281/zenodo.15625651">CSV (metadata)</a>, <a href="https://doi.org/10.5281/zenodo.15855111">Kubernetes-ready database</a>, <a href="https://doi.org/10.5281/zenodo.17483301">RDF (metadata and provenance)</a>, and <a href="https://doi.org/10.6084/m9.figshare.29543783.v1">RDF (provenance database)</a>.</p>
+                                        </div>
+                                    </div>
+                                </div>
                                 <div class="accordion-item">
                                     <h2 class="accordion-header">
                                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#meta-dump1">


### PR DESCRIPTION
Update download links and statistics for the January 2026 release:
- 129,436,832 bibliographic entities
- 389,069,283 authors, 2,862,406 editors, 106,791,171 publishers
- 1,376,246 publication venues
- Data sources: Crossref September 2025, DataCite 2025

Move June 2025 dump to previous dumps section.